### PR TITLE
Use MakerDAO pinned nixpkgs expression

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,12 +1,17 @@
 FROM nixos/nix:2.1.3
 
-RUN apk add --no-cache git bash openssh jq bc && \
+ENV XDG_CACHE_HOME=/nix/cache
+
+RUN apk add --no-cache git bash openssh && \
     . "$HOME/.nix-profile/etc/profile.d/nix.sh" && \
-    nix-env -if https://github.com/cachix/cachix/tarball/master \
+    nix run -f https://github.com/cachix/cachix/tarball/master \
         --substituters https://cachix.cachix.org \
-        --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM= && \
-    cachix use dapp && \
-    git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools && \
-    nix-env -f $HOME/.dapp/dapptools -iA dapp seth solc ethsign && \
+        --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM= \
+        -c sh -c "cachix use dapp && cachix use tdds" && \
+    nix-env -f https://github.com/makerdao/nixpkgs-pin/tarball/master -iA pkgs.makerCommonScriptBins && \
     rm -rf /var/cache/apk/* && \
-    nix-collect-garbage -d
+    nix-collect-garbage -d && \
+    nix-store --optimise && \
+    nix-env -q
+
+VOLUME /nix


### PR DESCRIPTION
- add `tdds.cachix.org` to Nix build caches
- pre-install dependencies from our common pinned Nix expressions: <https://github.com/makerdao/nixpkgs-pin>
- set Nix tarball/git cache to reside in `/nix` directory
- set `/nix` as a docker volume to be able to share Nix store across containers