### PR TITLE
STAX-14 Read `.staxx` manifest file from deploy repo root instead of `deploy-testchain.json`

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -294,7 +294,7 @@ func (c *Component) getManifest(log *logrus.Entry) (*Manifest, error) {
 type ReadFile func(path string) ([]byte, error)
 
 func readManifestFile(readFile ReadFile, repoPath string) (*Manifest, error) {
-	path := filepath.Join(repoPath, ".staxx")
+	path := filepath.Join(repoPath, ".staxx-scenarios")
 	data, err := readFile(path)
 	if err != nil {
 		return nil, err

--- a/pkg/deploy/manifest_test.go
+++ b/pkg/deploy/manifest_test.go
@@ -1,0 +1,140 @@
+package deploy
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestReadManifestFile(t *testing.T) {
+	// Mock
+	stepConfigTmpl := `{
+		"description": "%s",
+		"defaults": {},
+		"roles": ["CREATOR"],
+		"omniaFromAddr": "0xdc9A20F5a46AFE0802b361076BeFC51f787B2e58",
+		"pauseDelay": "0"
+	}`
+	mockFileReader := func(path string) ([]byte, error) {
+		t.Logf("mock file reader: %s", path)
+		switch path {
+		case ".staxx":
+			return []byte(`{
+				"name": "TestManifest",
+				"description": "",
+				"scenarios": [
+					{
+						"name": "TestScenario1",
+						"description": "",
+						"run": "deploy-step-1",
+						"config": "testconfig1.json"
+					},
+					{
+						"name": "TestScenario2",
+						"description": "",
+						"run": "deploy-step-2",
+						"config": "testconfig2.json"
+					}
+				]
+			}`), nil
+		default:
+			return []byte(fmt.Sprintf(stepConfigTmpl, path)), nil
+		}
+	}
+
+	// Run
+	manifest, err := readManifestFile(mockFileReader, ".")
+	if err != nil {
+		t.Error(err)
+	}
+
+	scenario1 := manifest.Scenarios[0]
+	scenario2 := manifest.Scenarios[1]
+
+	// Assertion
+	if manifest.Name != "TestManifest" {
+		t.Errorf("Manifest name doesn't match unmarshaled name: %s", manifest.Name)
+	}
+	if scenario1.Name != "TestScenario1" {
+		t.Errorf("Scenario 1's name doesnt match unmarshaled name: %s", scenario1.Name)
+	}
+	if scenario1.RunCommand != "deploy-step-1" {
+		t.Errorf("Scenario 1's run command doesn't match unmarshaled run command: %s", scenario1.RunCommand)
+	}
+	if string(scenario1.Config) != fmt.Sprintf(stepConfigTmpl, "testconfig1.json") {
+		t.Errorf("Scenario 1's config file content doesn't match: %s", scenario1.Config)
+	}
+	if scenario2.Name != "TestScenario2" {
+		t.Errorf("Scenario 2's name doesn't match unmarshaled name: %s", scenario2.Name)
+	}
+}
+
+func TestNewStepListFromManifest(t *testing.T) {
+	// Setup
+	manifest := Manifest{
+		"TestManifest",
+		"A test manifest",
+		[]Scenario{
+			{
+				"TestScenario1!",
+				"A test scenario",
+				"true",
+				[]byte(
+					`{
+						"description": "Step 1",
+						"defaults": {},
+						"roles": ["CREATOR"],
+						"omniaFromAddr": "0xdc9A20F5a46AFE0802b361076BeFC51f787B2e58",
+						"pauseDelay": "0"
+					}`,
+				),
+			},
+			{
+				"TestScenario2!",
+				"Another test scenario",
+				"true",
+				[]byte(
+					`{
+						"description": "Step 2",
+						"defaults": {},
+						"roles": ["CREATOR"],
+						"omniaFromAddr": "0xdc9A20F5a46AFE0802b361076BeFC51f787B2e58",
+						"pauseDelay": "0"
+					}`,
+				),
+			},
+		},
+	}
+
+	// Run
+	stepList, err := NewStepListFromManifest(&manifest)
+	if err != nil {
+		t.Error(err)
+	}
+
+	step1 := stepList[0]
+	step2 := stepList[1]
+
+	// Assertion
+	if step1.ID != 1 {
+		t.Errorf("Scenario nr 1 doesn't map to step id 1, but instead: %d", step1.ID)
+	}
+	if step1.Description != "Step 1" {
+		t.Errorf("Scenario nr 1's description doesn't match step 1's: %s", step1.Description)
+	}
+	if step1.OmniaFromAddress != "0xdc9A20F5a46AFE0802b361076BeFC51f787B2e58" {
+		t.Errorf("Scenario nr 1's config file content doesn't match step 1's defaults: %s", step1.Defaults)
+	}
+	if string(step1.Defaults) != "{}" {
+		t.Errorf("Scenario nr 1's config file content doesn't match step 1's defaults: %s", step1.Defaults)
+	}
+
+	if step2.ID != 2 {
+		t.Errorf("Scenario nr 2 doesn't map to step id 2, but instead: %d", step2.ID)
+	}
+	if step2.Description != "Step 2" {
+		t.Errorf("Scenario nr 2's description doesn't match step 2's: %s", step2.Description)
+	}
+	if string(step2.Defaults) != "{}" {
+		t.Errorf("Scenario nr 2's config file content doesn't match step 2's defaults: %s", step2.Defaults)
+	}
+}

--- a/pkg/deploy/manifest_test.go
+++ b/pkg/deploy/manifest_test.go
@@ -17,7 +17,7 @@ func TestReadManifestFile(t *testing.T) {
 	mockFileReader := func(path string) ([]byte, error) {
 		t.Logf("mock file reader: %s", path)
 		switch path {
-		case ".staxx":
+		case ".staxx-scenarios":
 			return []byte(`{
 				"name": "TestManifest",
 				"description": "",

--- a/pkg/deploy/models.go
+++ b/pkg/deploy/models.go
@@ -19,6 +19,45 @@ type StepModel struct {
 	Ilks             json.RawMessage `json:"ilks"`
 }
 
+type Manifest struct {
+	Name        string
+	Description string
+	Scenarios   []Scenario
+}
+
+type Scenario struct {
+	Name        string
+	Description string
+	RunCommand  string
+	Config      json.RawMessage
+}
+
+type ManifestModel struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Scenarios   []ScenarioModel `json:"scenarios"`
+}
+
+type ScenarioModel struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	RunCommand  string `json:"run"`
+	ConfigPath  string `json:"config"`
+}
+
+func NewStepListFromManifest(manifest *Manifest) ([]StepModel, error) {
+	stepList := make([]StepModel, len(manifest.Scenarios))
+	for i, scenario := range manifest.Scenarios {
+		var step StepModel
+		if err := json.Unmarshal(scenario.Config, &step); err != nil {
+			return nil, err
+		}
+		step.ID = i + 1
+		stepList[i] = step
+	}
+	return stepList, nil
+}
+
 type ResultErrorModel struct {
 	Msg       string `json:"msg"`
 	StderrB64 string `json:"stderrB64"`

--- a/pkg/service/methods/run.go
+++ b/pkg/service/methods/run.go
@@ -36,7 +36,7 @@ func (m *Methods) Run(
 		resultReq := &gateway.RunResultRequest{
 			ID: id,
 		}
-		if resErr := m.deployComponent.RunStep(log, req.StepID, req.EnvVars); resErr != nil {
+		if resErr := m.deployComponent.RunScenario(log, req.StepID, req.EnvVars); resErr != nil {
 			resultReq.Type = gateway.RunResultRequestTypeErr
 			errResBytes, err := json.Marshal(resErr)
 			if err != nil {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -44,7 +44,7 @@ func (w *Worker) Run(log *logrus.Entry) error {
 		ID: runConfig.RequestID,
 	}
 
-	if resErr := w.deployComponent.RunStep(log, runConfig.StepID, runConfig.DeployEnvVars); resErr != nil {
+	if resErr := w.deployComponent.RunScenario(log, runConfig.StepID, runConfig.DeployEnvVars); resErr != nil {
 		resultReq.Type = gateway.RunResultRequestTypeErr
 		errResBytes, err := json.Marshal(resErr)
 		if err != nil {


### PR DESCRIPTION
This is the first iteration of introducing a manifest deploy file.

The manifest file should be named `.staxx` and placed in the root of the deploy script repo.

Some changes have been made to the internal semantics, `steps` have been renamed to `scenarios` as this is a more general concept. Steps can still be implemented using scenarios by the user in the manifest file. The API still uses the `step` semantic and can be refactored when `scenarios` are propagated to the UI.

An example manifest file:

```json
{
  "name": "dss-deploy-scripts",
  "description": "MCD deployment",
  "scenarios": [
    {
      "name": "scenario1",
      "description": "MCD - general deployment",
      "run": "deploy-testchain.sh",
      "config": "deploy-testchain.json"
    },
    {
      "name": "scenario2",
      "description": "MCD - some special setup",
      "run": "deploy-testchain.sh",
      "config": "deploy-testchain.json"
    }
  ]
}
```