### PR TITLE
Bump base image to use nix 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,14 @@ a scenario sends the result to the `staxx` gateway and exits.
 ### Run worker
 
 ```sh
-REQUEST_ID=1337
-SCENARIO_NR=0
-REPO_URL="https://github.com/makerdao/dss-deploy-scripts"
-REPO_REF="staxx-deploy"
-REPO_REV="a3410d6d6a375ac3e04c7bee983ead7710efa0e0"
-DEPLOY_ENV='{"ETH_FROM":"0x4af990932fa5cadd22398de0485850a5c9ca1350","ETH_GAS":"7000000","ETH_KEYSTORE":"~/.dapp/testnet/8545/keystore","ETH_PASSWORD":"/dev/null","ETH_RPC_URL":"http://localhost:8545"}'
+export REQUEST_ID=1337
+export SCENARIO_NR=0
+export REPO_URL="https://github.com/makerdao/dss-deploy-scripts"
+export REPO_REF="staxx-deploy"
+export DEPLOY_ENV='{"ETH_FROM":"0x980957073687abbfc85609ecd7c118d2b7506a17","ETH_GAS":"7000000","ETH_KEYSTORE":"~/.dapp/testnet/8545/keystore","ETH_PASSWORD":"/dev/null","ETH_RPC_URL":"http://localhost:8545"}'
 
-make run GOOS=linux  # for linux
-make run GOOS=darwin # for mac
+make run-worker GOOS=linux  # for linux
+make run-worker GOOS=darwin # for mac
 ```
 
 ## Build and run info service

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,14 +1,14 @@
-FROM nixos/nix:2.1.3
+FROM nixos/nix:2.3
 
 ENV XDG_CACHE_HOME=/nix/cache
 
 RUN apk add --no-cache git bash openssh && \
     . "$HOME/.nix-profile/etc/profile.d/nix.sh" && \
-    nix run -f https://github.com/cachix/cachix/tarball/master \
+    nix run --verbose -f https://github.com/cachix/cachix/tarball/master \
         --substituters https://cachix.cachix.org \
         --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM= \
         -c sh -c "cachix use dapp && cachix use tdds" && \
-    nix-env -f https://github.com/makerdao/nixpkgs-pin/tarball/master -iA pkgs.makerCommonScriptBins && \
+    nix-env --verbose -f https://github.com/makerdao/nixpkgs-pin/tarball/master -iA pkgs.makerCommonScriptBins && \
     rm -rf /var/cache/apk/* && \
     nix-collect-garbage -d && \
     nix-store --optimise && \


### PR DESCRIPTION
This fixes an issue with the nix function `fetchGit`, so that GIT refs are parsed correctly.